### PR TITLE
Read MCP servers from configuration

### DIFF
--- a/backend/src/main/java/org/shark/alma/mcp/McpClientApplication.java
+++ b/backend/src/main/java/org/shark/alma/mcp/McpClientApplication.java
@@ -2,11 +2,15 @@ package org.shark.alma.mcp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import org.shark.alma.mcp.config.McpProperties;
 
 /**
  * Main application class for MCP Client Backend
  */
 @SpringBootApplication
+@EnableConfigurationProperties(McpProperties.class)
 public class McpClientApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/org/shark/alma/mcp/config/McpProperties.java
+++ b/backend/src/main/java/org/shark/alma/mcp/config/McpProperties.java
@@ -1,0 +1,31 @@
+package org.shark.alma.mcp.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.shark.alma.mcp.model.McpServer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Data;
+
+/**
+ * Configuration properties for MCP servers.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "mcp")
+@Data
+public class McpProperties {
+
+    /**
+     * Configured MCP servers loaded from application.yml.
+     */
+    private List<McpServer> servers = new ArrayList<>();
+
+    @Data
+    public static class ServerConfig {
+        private int port;
+        private String host;
+    }
+    private ServerConfig server = new ServerConfig();
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,27 @@ mcp:
   server:
     port: 3000
     host: localhost
+  servers:
+    - id: melian-local
+      name: "Melian MCP Server (Local)"
+      description: "Local MELIAN - M\xF3dulo de Embedding y L\xF3gica Inteligente para Acceso Natural. Provides movie data from TMDB, SQL databases, and MongoDB."
+      url: "stdio://java -jar ../target/melian-*.jar"
+    - id: github-mcp
+      name: "GitHub MCP Server"
+      description: "Provides access to GitHub repositories, issues, and pull requests"
+      url: "stdio://npx @modelcontextprotocol/server-github"
+    - id: filesystem-mcp
+      name: "File System MCP Server"
+      description: "Provides secure access to local file system operations"
+      url: "stdio://npx @modelcontextprotocol/server-filesystem"
+    - id: brave-search-mcp
+      name: "Brave Search MCP Server"
+      description: "Provides web search capabilities through Brave Search API"
+      url: "stdio://npx @modelcontextprotocol/server-brave-search"
+    - id: sqlite-mcp
+      name: "SQLite MCP Server"
+      description: "Provides database query capabilities for SQLite databases"
+      url: "stdio://npx @modelcontextprotocol/server-sqlite"
 
 spring:
   application:


### PR DESCRIPTION
## Summary
- load `McpServerService` configuration from `application.yml`
- expose a new `McpProperties` class
- enable configuration properties in the main application
- define default MCP servers in the Spring YAML

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: command not found)*
- `npm run lint --prefix ui` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687d63092b64832e87d1828c5514de94