### PR TITLE
Add RestAssured integration tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -95,6 +95,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/test/java/org/shark/mentor/mcp/IntegrationTestConfig.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/IntegrationTestConfig.java
@@ -1,0 +1,13 @@
+package org.shark.mentor.mcp;
+
+import org.shark.mentor.mcp.service.LlmService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class IntegrationTestConfig {
+    @Bean
+    public LlmService llmService() {
+        return (prompt, context) -> "test-response";
+    }
+}

--- a/backend/src/test/java/org/shark/mentor/mcp/controller/ChatControllerIntegrationTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/controller/ChatControllerIntegrationTest.java
@@ -1,0 +1,76 @@
+package org.shark.mentor.mcp.controller;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.shark.mentor.mcp.IntegrationTestConfig;
+import org.shark.mentor.mcp.McpClientApplication;
+import org.shark.mentor.mcp.model.McpRequest;
+import org.shark.mentor.mcp.model.McpServer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(classes = McpClientApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(IntegrationTestConfig.class)
+@Tag("integration")
+class ChatControllerIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void sendMessageAndRetrieveConversation() {
+        String serverId = "chat-stdio";
+        McpServer server = new McpServer(serverId, "Chat Server", "desc", "stdio://cat", "DISCONNECTED");
+
+        given()
+            .contentType("application/json")
+            .body(server)
+        .when()
+            .post("/api/mcp/servers")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .post("/api/mcp/servers/{id}/connect", serverId)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("CONNECTED"));
+
+        McpRequest request = McpRequest.builder()
+                .serverId(serverId)
+                .message("hello")
+                .conversationId("conv1")
+                .build();
+
+        given()
+            .contentType("application/json")
+            .body(request)
+        .when()
+            .post("/api/mcp/chat/send")
+        .then()
+            .statusCode(200)
+            .body("role", equalTo("ASSISTANT"))
+            .body("serverId", equalTo(serverId))
+            .body("content", equalTo("test-response"));
+
+        given()
+        .when()
+            .get("/api/mcp/chat/conversations/conv1")
+        .then()
+            .statusCode(200)
+            .body("size()", equalTo(2));
+    }
+}

--- a/backend/src/test/java/org/shark/mentor/mcp/controller/McpServerControllerIntegrationTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/controller/McpServerControllerIntegrationTest.java
@@ -1,0 +1,65 @@
+package org.shark.mentor.mcp.controller;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.shark.mentor.mcp.IntegrationTestConfig;
+import org.shark.mentor.mcp.McpClientApplication;
+import org.shark.mentor.mcp.model.McpServer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(classes = McpClientApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(IntegrationTestConfig.class)
+@Tag("integration")
+class McpServerControllerIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void addConnectAndRemoveServer() {
+        String serverId = "test-stdio";
+        McpServer server = new McpServer(serverId, "Test Server", "desc", "stdio://cat", "DISCONNECTED");
+
+        given()
+            .contentType("application/json")
+            .body(server)
+        .when()
+            .post("/api/mcp/servers")
+        .then()
+            .statusCode(200)
+            .body("id", equalTo(serverId));
+
+        given()
+        .when()
+            .post("/api/mcp/servers/{id}/connect", serverId)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("CONNECTED"));
+
+        given()
+        .when()
+            .post("/api/mcp/servers/{id}/disconnect", serverId)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("DISCONNECTED"));
+
+        given()
+        .when()
+            .delete("/api/mcp/servers/{id}", serverId)
+        .then()
+            .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add RestAssured test dependency
- create `IntegrationTestConfig` with a stub `LlmService`
- add `McpServerControllerIntegrationTest`
- add `ChatControllerIntegrationTest`

## Testing
- `mvn -q -pl backend test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8801bb98832ebfa499f5638bcaf0