### PR TITLE
Add collapsible sidebar and scrollable chat

### DIFF
--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -157,7 +157,7 @@ export const ChatInterface = ({ selectedServer }) => {
         </div>
 
         <div className="chat-messages">
-          <ScrollPanel ref={scrollPanelRef} className="chat-scroll-panel">
+          <ScrollPanel ref={scrollPanelRef} className="chat-scroll-panel" style={{ height: '100%' }}>
             {messages.length === 0 ? (
               <div className="chat-welcome">
                 <h4>Welcome to {selectedServer.name}</h4>

--- a/ui/src/components/McpHeader.jsx
+++ b/ui/src/components/McpHeader.jsx
@@ -1,10 +1,17 @@
 import '../styles/header.css';
 import logo from '../assets/shark-ia.png';
+import { Button } from 'primereact/button';
 
-export const McpHeader = () => {
+export const McpHeader = ({ onToggleSidebar, sidebarCollapsed }) => {
   return (
     <header className="header-container">
       <div className="header-logo">
+        <Button
+          icon="pi pi-bars"
+          className="p-button-text sidebar-toggle-button"
+          onClick={onToggleSidebar}
+          aria-label="Toggle sidebar"
+        />
         <img src={logo} alt="Logo" className="logo" height={80} width={100} />
         <h1 className="header-title">MCP Client - Model Context Protocol Interface</h1>
       </div>

--- a/ui/src/pages/McpClientApp.jsx
+++ b/ui/src/pages/McpClientApp.jsx
@@ -7,6 +7,9 @@ import '../styles/mcp-client-app.css';
 const McpClientApp = () => {
   const [selectedServer, setSelectedServer] = useState(null);
   const [servers, setServers] = useState([]);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+  const toggleSidebar = () => setSidebarCollapsed(prev => !prev);
 
   const handleServerSelect = (server) => {
     setSelectedServer(server);
@@ -26,9 +29,9 @@ const McpClientApp = () => {
 
   return (
       <div className="mcp-client-app">
-        <McpHeader />
+        <McpHeader onToggleSidebar={toggleSidebar} sidebarCollapsed={sidebarCollapsed} />
         <div className="mcp-client-main">
-          <div className="mcp-client-sidebar">
+          <div className={`mcp-client-sidebar${sidebarCollapsed ? ' collapsed' : ''}`}>
             <McpServerList
                 onServerSelect={handleServerSelect}
                 selectedServerId={selectedServer?.id}

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -43,6 +43,10 @@
   height: 100%;
 }
 
+.chat-scroll-panel .p-scrollpanel-wrapper {
+  overflow-y: auto;
+}
+
 .chat-welcome {
   padding: 2rem;
   text-align: center;

--- a/ui/src/styles/header.css
+++ b/ui/src/styles/header.css
@@ -21,6 +21,11 @@
     gap: 18px;
 }
 
+.sidebar-toggle-button {
+    color: #fff;
+    margin-right: 0.5rem;
+}
+
 .header-title {
     color: #fff;
     font-size: 1.5rem;

--- a/ui/src/styles/mcp-client-app.css
+++ b/ui/src/styles/mcp-client-app.css
@@ -21,6 +21,13 @@
   border-right: 1px solid #e9ecef;
 }
 
+.mcp-client-sidebar.collapsed {
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+  border-right: none;
+}
+
 .mcp-client-chat {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary
- add sidebar collapse toggle in header
- make sidebar width 0 when collapsed
- let chat scroll when height is exceeded

## Testing
- `npm --prefix ui run lint` *(fails: ESLint couldn't find config)*
- `mvn -q -f backend/pom.xml test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68851a879104832ea4728cfb29c986bb