### PR TITLE
Add collapsible sidebar and scrolling

### DIFF
--- a/ui/src/components/McpHeader.jsx
+++ b/ui/src/components/McpHeader.jsx
@@ -6,7 +6,7 @@ export const McpHeader = ({ onToggleSidebar, sidebarCollapsed }) => {  return (
     <header className="header-container">
       <div className="header-logo">
           <Button
-              icon="pi pi-bars"
+              icon={sidebarCollapsed ? 'pi pi-bars' : 'pi pi-angle-left'}
               className="p-button-text sidebar-toggle-button"
               onClick={onToggleSidebar}
               aria-label="Toggle sidebar"

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -41,6 +41,7 @@
 .chat-scroll-panel {
   flex: 1;
   height: 100%;
+  overflow-y: auto;
 }
 
 .chat-welcome {

--- a/ui/src/styles/header.css
+++ b/ui/src/styles/header.css
@@ -32,6 +32,11 @@
     object-fit: contain;
 }
 
+.sidebar-toggle-button {
+    margin-right: 8px;
+    color: #fff;
+}
+
 .header-button-item {
     background: transparent;
     padding: 0.75rem 1.5rem;

--- a/ui/src/styles/mcp-client-app.css
+++ b/ui/src/styles/mcp-client-app.css
@@ -19,6 +19,13 @@
   flex-direction: column;
   background: #f8f9fa;
   border-right: 1px solid #e9ecef;
+  transition: width 0.3s ease;
+  overflow: hidden;
+}
+
+.mcp-client-sidebar.collapsed {
+  width: 0;
+  min-width: 0;
 }
 
 .mcp-client-chat {


### PR DESCRIPTION
## Summary
- make sidebar collapsible
- toggle collapse from header
- make chat messages scrollable
- style sidebar toggle button

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688527300504832e8c1096ce297e937c