### PR TITLE
Add context-based LLM prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ with the running application.
 1. Open http://localhost:5174 in your browser
 2. Select an MCP server from the left sidebar
 3. Start chatting with the selected server
+4. The assistant responds strictly using the context returned by the MCP server
+   and avoids inferring or adding new information
 
 ## Make Targets
 

--- a/backend/src/main/java/org/shark/mentor/mcp/service/ChatService.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/ChatService.java
@@ -75,8 +75,7 @@ public class ChatService {
         ChatMessage contextMessage = communicateWithMcpServer(request, server);
 
         // Generate the final response using the configured LLM
-        /// String llmOutput = llmService.generate(request.getMessage(), contextMessage.getContent());
-        String llmOutput = llmService.generate(contextMessage.getContent(), null);
+        String llmOutput = llmService.generate(request.getMessage(), contextMessage.getContent());
         ChatMessage assistantMessage = ChatMessage.builder()
             .id(UUID.randomUUID().toString())
             .role("ASSISTANT")

--- a/backend/src/main/java/org/shark/mentor/mcp/service/LlmService.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/LlmService.java
@@ -1,5 +1,15 @@
 package org.shark.mentor.mcp.service;
 
 public interface LlmService {
-    String generate(String prompt, String context);
+
+    /**
+     * Generate a response to the given question using only the supplied context.
+     * Implementations must not infer or add information that is not present in
+     * the context.
+     *
+     * @param question the user's original question
+     * @param context  additional information retrieved from the MCP server
+     * @return the model generated answer
+     */
+    String generate(String question, String context);
 }

--- a/backend/src/main/java/org/shark/mentor/mcp/service/LlmServiceLangchain4j.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/LlmServiceLangchain4j.java
@@ -26,9 +26,17 @@ public class LlmServiceLangchain4j implements LlmService {
     }
 
     @Override
-    public String generate(String mcpAnswer, String context) {
-        String prompt = "Reformula la siguiente respuesta en lenguaje natural, sin agregar ni inferir información. Solo usa el contenido proporcionado:\n\n"
-                + mcpAnswer;
-        return chatModel.generate(prompt);
+    public String generate(String question, String context) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("Responde \u00fanicamente utilizando la informaci\u00f3n del contexto proporcionado. ")
+              .append("No infieras ni agregues datos que no est\u00e9n en el contexto.");
+
+        if (context != null && !context.isBlank()) {
+            prompt.append("\n\nContexto:\n").append(context);
+        }
+
+        prompt.append("\n\nPregunta del usuario: ").append(question);
+
+        return chatModel.generate(prompt.toString());
     }
 }


### PR DESCRIPTION
## Summary
- refine `LlmService` API documentation
- implement context-aware prompt in `LlmServiceLangchain4j`
- call LLM with question and context from `ChatService`
- clarify in README that answers are based solely on MCP context

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68853a7a80cc832ebece4ec4ab381221