### PR TITLE
Add clear chat button

### DIFF
--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -91,6 +91,26 @@ export const ChatInterface = ({ selectedServer }) => {
     }
   };
 
+  const handleClearMessages = async () => {
+    try {
+      await chatService.clearConversation(BACKEND_URL, conversationId);
+      setMessages([]);
+      toast.current?.show({
+        severity: 'success',
+        summary: 'Cleared',
+        detail: 'Conversation cleared',
+        life: 2000,
+      });
+    } catch (error) {
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to clear conversation',
+        life: 3000,
+      });
+    }
+  };
+
   const handleKeyPress = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -163,6 +183,15 @@ export const ChatInterface = ({ selectedServer }) => {
             <div className="chat-server-info">
               <h3>{selectedServer.name}</h3>
               <p>{selectedServer.description}</p>
+            </div>
+            <div className="chat-header-actions">
+              <Button
+                  icon="pi pi-trash"
+                  className="p-button-text"
+                  onClick={handleClearMessages}
+                  disabled={messages.length === 0}
+                  tooltip="Clear conversation"
+              />
             </div>
           </div>
 

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -18,6 +18,14 @@
   border-bottom: 1px solid #e0e0e0;
   background: #f8f9fa;
   flex-shrink: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chat-header-actions {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .chat-server-info h3 {


### PR DESCRIPTION
## Summary
- add a button in the chat header to clear conversation
- show a toast when chat is cleared
- style the chat header for the new action button

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68866e4c4380832ebd7c10c3581b3975