### PR TITLE
Implement stdio tool listing and ping support

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/controller/McpServerController.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/controller/McpServerController.java
@@ -97,6 +97,22 @@ public class McpServerController {
         }
     }
 
+    @GetMapping("/{id}/ping")
+    public ResponseEntity<String> pingServer(@PathVariable String id) {
+        log.info("Pinging MCP server: {}", id);
+        try {
+            boolean ok = mcpServerService.pingServer(id);
+            if (ok) {
+                return ResponseEntity.ok("pong");
+            } else {
+                return ResponseEntity.status(503).body("unreachable");
+            }
+        } catch (IllegalArgumentException e) {
+            log.error("Server not found: {}", id);
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     @GetMapping("/status")
     public ResponseEntity<String> getConnectionStatus() {
         long connectedCount = mcpServerService.getConnectedServersCount();


### PR DESCRIPTION
## Summary
- implement `getToolsViaStdio` with initialization handshake
- track initialized stdio servers
- add ping verification in `McpServerService`
- expose `/ping` endpoint on server controller

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688d2f2b83c4832eb71c058ac6213848