### PR TITLE
Show server tools on initial connection

### DIFF
--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -28,6 +28,21 @@ export const ChatInterface = ({ selectedServer }) => {
     try {
       const history = await chatService.getConversation(BACKEND_URL, conversationId);
       setMessages(history);
+
+      // If this is the first connection, request available tools
+      if (history.length === 0 && selectedServer.status === 'CONNECTED') {
+        try {
+          const initial = await chatService.sendMessage(
+            BACKEND_URL,
+            selectedServer.id,
+            '',
+            conversationId
+          );
+          setMessages([initial]);
+        } catch (err) {
+          console.error('Failed to load initial tools', err);
+        }
+      }
     } catch (error) {
       setMessages([]);
       toast.current?.show({


### PR DESCRIPTION
## Summary
- Request initial tools from MCP server when opening a new conversation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893e2f4ad20832e818385ae32cd60ac