### PR TITLE
Add logging for server tool review to diagnose delay

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/controller/McpToolController.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/controller/McpToolController.java
@@ -25,10 +25,13 @@ public class McpToolController {
      */
     @GetMapping("/{serverId}")
     public ResponseEntity<List<Map<String, Object>>> listTools(@PathVariable String serverId) {
+        long start = System.currentTimeMillis();
         log.info("Listando tools para el servidor {}", serverId);
         McpServer server = mcpServerService.getServer(serverId)
                 .orElseThrow(() -> new IllegalArgumentException("Servidor no encontrado: " + serverId));
         List<Map<String, Object>> tools = mcpToolService.getTools(server);
+        long duration = System.currentTimeMillis() - start;
+        log.info("Se obtuvieron {} tools para el servidor {} en {} ms", tools.size(), serverId, duration);
         return ResponseEntity.ok(tools);
     }
 }

--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -57,10 +57,17 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
 
   useEffect(() => {
     if (!selectedServer) return;
+    console.log(`[ChatInterface] Cargando tools para ${selectedServer.id}`);
     // Cargar tools del servidor seleccionado
     getServerTools(selectedServer.id)
-      .then(setTools)
-      .catch(() => setTools([]));
+      .then((loadedTools) => {
+        console.log(`[ChatInterface] Tools cargadas para ${selectedServer.id}`, loadedTools);
+        setTools(loadedTools);
+      })
+      .catch((err) => {
+        console.error(`[ChatInterface] Error cargando tools para ${selectedServer.id}`, err);
+        setTools([]);
+      });
     loadConversation();
   }, [selectedServer]);
 

--- a/ui/src/services/toolService.js
+++ b/ui/src/services/toolService.js
@@ -1,8 +1,23 @@
 // Servicio para obtener tools del backend
 export async function getServerTools(serverId) {
   const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8083';
-  const response = await fetch(`${BACKEND_URL}/api/mcp/tools/${serverId}`);
-  if (!response.ok) throw new Error('Failed to fetch tools');
-  return await response.json();
+  const url = `${BACKEND_URL}/api/mcp/tools/${serverId}`;
+  console.log(`[toolService] Solicitando tools de ${url}`);
+  const start = performance.now();
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error(`[toolService] Error en la solicitud a ${url}: ${response.status}`);
+      throw new Error('Failed to fetch tools');
+    }
+    const data = await response.json();
+    const elapsed = Math.round(performance.now() - start);
+    console.log(`[toolService] Tools recibidas de ${serverId} en ${elapsed}ms`, data);
+    return data;
+  } catch (error) {
+    const elapsed = Math.round(performance.now() - start);
+    console.error(`[toolService] Falló la obtención de tools para ${serverId} después de ${elapsed}ms`, error);
+    throw error;
+  }
 }
 


### PR DESCRIPTION
## Summary
- log tool retrieval time in McpToolController
- add client side logging around fetching tools
- include timing and error logs in toolService

## Testing
- `mvn -q -pl backend test` (fails: Non-resolvable parent POM)
- `npm test` (fails: Missing script 'test')
- `npm run lint` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68967a56e1b4832ebca40a440e2b7b5f