### PR TITLE
Handle HTTP 405 in server detection

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/service/McpServerService.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/McpServerService.java
@@ -262,8 +262,8 @@ public class McpServerService {
                 log.info("HTTP connection successful to {}", server.getUrl());
                 server.setStatus("CONNECTED");
                 server.setLastError(null);
-            } else if (response.statusCode() == 404 || response.statusCode() == 400) {
-                // Si /mcp/health no existe, intentar la raíz
+            } else if (response.statusCode() == 404 || response.statusCode() == 405 || response.statusCode() == 400) {
+                // Si /mcp/health no existe o no permite GET, intentar la raíz
                 log.info("Health endpoint not found, trying root endpoint for {}", server.getUrl());
                 HttpRequest rootRequest = HttpRequest.newBuilder()
                         .uri(URI.create(server.getUrl()))
@@ -277,9 +277,9 @@ public class McpServerService {
                     log.info("HTTP connection successful to root endpoint {}", server.getUrl());
                     server.setStatus("CONNECTED");
                     server.setLastError(null);
-                } else if (rootResponse.statusCode() == 404) {
-                    // Si la raíz tampoco existe, intentar un endpoint funcional
-                    log.info("Root endpoint returned 404, trying tools list endpoint for {}", server.getUrl());
+                } else if (rootResponse.statusCode() == 404 || rootResponse.statusCode() == 405) {
+                    // Si la raíz tampoco existe o no permite GET, intentar un endpoint funcional
+                    log.info("Root endpoint returned {} , trying tools list endpoint for {}", rootResponse.statusCode(), server.getUrl());
                     String toolsUrl = server.getUrl() + "/mcp/tools/list";
                     HttpRequest toolsRequest = HttpRequest.newBuilder()
                             .uri(URI.create(toolsUrl))

--- a/backend/src/test/java/org/shark/mentor/mcp/service/McpServerServiceHttpTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/McpServerServiceHttpTest.java
@@ -1,0 +1,58 @@
+package org.shark.mentor.mcp.service;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.shark.mentor.mcp.config.McpProperties;
+import org.shark.mentor.mcp.model.McpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class McpServerServiceHttpTest {
+
+    private HttpServer httpServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+        httpServer.createContext("/mcp/health", exchange -> {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+        });
+        httpServer.createContext("/mcp/tools/list", exchange -> {
+            byte[] resp = "{}".getBytes();
+            exchange.sendResponseHeaders(200, resp.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(resp);
+            }
+        });
+        httpServer.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+        });
+        httpServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        httpServer.stop(0);
+    }
+
+    @Test
+    void connectHttpTreats405AsNotFound() {
+        int port = httpServer.getAddress().getPort();
+        McpProperties properties = new McpProperties();
+        McpServerService service = new McpServerService(properties);
+        McpServer server = new McpServer("test", "Test", "", "http://localhost:" + port, "DISCONNECTED");
+        service.addServer(server);
+
+        McpServer result = service.connectToServer("test");
+
+        assertEquals("CONNECTED", result.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- Treat HTTP 405 like 404/400 in `connectHttp` so servers that reject GET on `/mcp/health` or `/` fall back to `/mcp/tools/list`
- Add unit test confirming 405 responses still lead to successful connection

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689691ad3ea8832e8cc4208447acfaeb