### PR TITLE
Make server info collapsible and enable chat panel scrolling

### DIFF
--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -18,6 +18,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
   const [inputMessage, setInputMessage] = useState('');
   const [loading, setLoading] = useState(false);
   const [tools, setTools] = useState([]);
+  const [infoCollapsed, setInfoCollapsed] = useState(false);
   const toast = useRef(null);
   const scrollPanelRef = useRef(null);
 
@@ -239,20 +240,31 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
         <Card className="chat-container">
           <div className="chat-header">
             <div className="chat-server-info">
-              <h3>{selectedServer.name}</h3>
-              <p>{selectedServer.description}</p>
-              {/* Mostrar tools del servidor */}
-              {tools.length > 0 && (
-                <div className="chat-server-tools">
-                  <strong>Herramientas disponibles:</strong>
-                  <ul>
-                    {tools.map(tool => (
-                      <li key={tool.name}>
-                        <b>{tool.name}</b>: {tool.description}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+              <div className="chat-server-info-header">
+                <h3>{selectedServer.name}</h3>
+                <Button
+                  icon={infoCollapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'}
+                  className="p-button-text p-button-rounded p-button-sm"
+                  onClick={() => setInfoCollapsed(prev => !prev)}
+                />
+              </div>
+              {!infoCollapsed && (
+                <>
+                  <p>{selectedServer.description}</p>
+                  {/* Mostrar tools del servidor */}
+                  {tools.length > 0 && (
+                    <div className="chat-server-tools">
+                      <strong>Herramientas disponibles:</strong>
+                      <ul>
+                        {tools.map(tool => (
+                          <li key={tool.name}>
+                            <b>{tool.name}</b>: {tool.description}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </>
               )}
             </div>
             <div className="chat-header-actions">

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: column;
   border-radius: 8px;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .chat-header {
@@ -28,9 +28,17 @@
   gap: 0.5rem;
 }
 
-.chat-server-info h3 {
-  margin: 0 0 0.5rem 0;
+.chat-server-info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.chat-server-info-header h3 {
+  margin: 0;
   color: #333;
+  flex: 1;
 }
 
 .chat-server-info p {


### PR DESCRIPTION
## Summary
- Add collapse toggle for server details and tool list above chat
- Allow chat container to scroll when content exceeds available space

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68969d24dce0832e849a80767349b2f7