### PR TITLE
Translate messages to English

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,17 +4,17 @@ FROM maven:3-eclipse-temurin-21-alpine AS builder
 
 WORKDIR /app
 
-# Copiar solo el POM para cachear dependencias
+# Copy only the POM to cache dependencies
 COPY backend/pom.xml .
 
-# Montamos cache Maven (funciona con BuildKit)
+# Mount Maven cache (works with BuildKit)
 RUN --mount=type=cache,target=/root/.m2 \
     mvn dependency:go-offline
 
-# Copiamos el resto del código fuente
+# Copy the rest of the source code
 COPY backend /app
 
-# Compilamos también usando cache de Maven
+# Build using Maven cache as well
 RUN --mount=type=cache,target=/root/.m2 \
     mvn clean package -DskipTests
 

--- a/backend/src/main/java/org/shark/mentor/mcp/model/McpServer.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/model/McpServer.java
@@ -26,7 +26,7 @@ public class McpServer {
 
 
 
-    // Constructor adicional para 5 parámetros
+    // Additional constructor for 5 parameters
     public McpServer(String id, String name, String description, String url, String status) {
         this.id = id;
         this.name = name;

--- a/backend/src/main/java/org/shark/mentor/mcp/service/ChatService.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/ChatService.java
@@ -99,11 +99,11 @@ public class ChatService {
         McpServer server = serverOpt.get();
         if (!"CONNECTED".equals(server.getStatus())) {
             String errorDetails = server.getLastError() != null ? " (Error: " + server.getLastError() + ")" : "";
-            String errorMessage = "El servidor no está conectado: " + server.getName() + errorDetails + ". Use el botón de conexión en la lista de servidores para intentar conectar.";
+            String errorMessage = "The server is not connected: " + server.getName() + errorDetails + ". Use the connection button in the server list to attempt to connect.";
             return createErrorMessage(request, errorMessage);
         }
 
-        // Detectar conexión inicial (mensaje vacío) y retornar herramientas disponibles
+        // Detect initial connection (empty message) and return available tools
         String query = request.getMessage();
         if (query == null || query.trim().isEmpty()) {
             return createInitialConnectionMessage(request, server);
@@ -129,10 +129,10 @@ public class ChatService {
             String assistantContent = enhancedLlmService.generateWithMemory(conversationId, query, context);
 
             if (assistantContent != null && assistantContent.startsWith("Error generating response:")) {
-                log.warn("El servicio LLM devolvió error para la conversación {}, usando contexto MCP: {}", conversationId, assistantContent);
+                log.warn("LLM service returned error for conversation {}, using MCP context: {}", conversationId, assistantContent);
                 assistantContent = formatMcpResponse(context, request.getMessage(), server.getName());
             } else {
-                log.info("Respuesta LLM generada exitosamente para la conversación {}", conversationId);
+                log.info("LLM response successfully generated for conversation {}", conversationId);
             }
 
             ChatMessage assistantMessage = ChatMessage.builder()
@@ -145,13 +145,13 @@ public class ChatService {
 
             addMessageToConversation(conversationId, assistantMessage);
 
-            log.info("Mensaje procesado exitosamente para conversación {} usando servidor {}", conversationId, server.getName());
+            log.info("Message processed successfully for conversation {} using server {}", conversationId, server.getName());
 
             return assistantMessage;
 
         } catch (Exception e) {
-            log.error("Error procesando mensaje en implementación simplificada para conversación {}: {}", conversationId, e.getMessage(), e);
-            return createErrorMessage(request, "Error procesando mensaje: " + e.getMessage());
+            log.error("Error processing message in simplified implementation for conversation {}: {}", conversationId, e.getMessage(), e);
+            return createErrorMessage(request, "Error processing message: " + e.getMessage());
         }
     }
     private ChatMessage createErrorMessage(McpRequest request, String errorMessage) {
@@ -167,7 +167,7 @@ public class ChatService {
     private ChatMessage createInitialConnectionMessage(McpRequest request, McpServer server) {
         StringBuilder messageContent = new StringBuilder();
 
-        // Obtener herramientas disponibles
+        // Retrieve available tools
         List<Map<String, Object>> tools = mcpToolService.getTools(server);
         
 //        if (!tools.isEmpty()) {
@@ -186,7 +186,7 @@ public class ChatService {
 //            messageContent.append("\n");
 //        }
         
-        messageContent.append("¿Qué pregunta tienes?");
+        messageContent.append("What is your question?");
         
         ChatMessage initialMessage = ChatMessage.builder()
                 .id(UUID.randomUUID().toString())
@@ -196,7 +196,7 @@ public class ChatService {
                 .serverId(request.getServerId())
                 .build();
         
-        // Agregar mensaje a la conversación
+        // Add message to the conversation
         String conversationId = request.getConversationId();
         if (conversationId == null) {
             conversationId = "default";
@@ -210,7 +210,7 @@ public class ChatService {
 
     private String formatMcpResponse(String mcpContext, String userMessage, String serverName) {
         if (mcpContext == null || mcpContext.trim().isEmpty()) {
-            return String.format("✅ Se contactó exitosamente con %s, pero no se devolvieron datos específicos para: \"%s\"", 
+            return String.format("✅ Successfully contacted %s, but no specific data was returned for: \"%s\"",
                     serverName, userMessage);
         }
         
@@ -230,13 +230,13 @@ public class ChatService {
 
     private String formatStructuredMcpResponse(JsonNode jsonNode, String serverName, String userMessage) {
         StringBuilder formattedResponse = new StringBuilder();
-        formattedResponse.append(String.format("✅ **Respuesta de %s**\n\n", serverName));
+        formattedResponse.append(String.format("✅ **Response from %s**\n\n", serverName));
         
 
          formattedResponse.append(formatGenericStructuredResponse(jsonNode));
 
         
-        formattedResponse.append(String.format("\n\n💡 *Información proporcionada por %s*", serverName));
+        formattedResponse.append(String.format("\n\n💡 *Information provided by %s*", serverName));
         return formattedResponse.toString();
     }
 
@@ -253,14 +253,14 @@ public class ChatService {
         
         if (files.isArray()) {
             for (JsonNode file : files) {
-                response.append(String.format("📄 **%s**\n", file.path("name").asText("archivo")));
+                response.append(String.format("📄 **%s**\n", file.path("name").asText("file")));
                 if (file.has("size")) {
-                    response.append(String.format("📏 Tamaño: %s\n", file.get("size").asText()));
+                    response.append(String.format("📏 Size: %s\n", file.get("size").asText()));
                 }
                 if (file.has("modified") || file.has("lastModified")) {
                     String modified = file.has("modified") ? file.get("modified").asText() :
                                      file.get("lastModified").asText();
-                    response.append(String.format("📅 Modificado: %s\n", modified));
+                    response.append(String.format("📅 Modified: %s\n", modified));
                 }
                 response.append("\n");
             }
@@ -273,7 +273,7 @@ public class ChatService {
 
     private String formatGenericStructuredResponse(JsonNode jsonNode) {
         StringBuilder response = new StringBuilder();
-        response.append("📋 **Información estructurada:**\n\n");
+        response.append("📋 **Structured information:**\n\n");
         
         try {
             String prettyJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
@@ -287,7 +287,7 @@ public class ChatService {
 
     private String formatRawMcpResponse(String mcpContext, String serverName) {
         StringBuilder response = new StringBuilder();
-        response.append(String.format("✅ **Respuesta de %s**\n\n", serverName));
+        response.append(String.format("✅ **Response from %s**\n\n", serverName));
         
         // Try to detect if it's a list or structured text
         if (mcpContext.contains("* ") || mcpContext.contains("- ")) {
@@ -306,7 +306,7 @@ public class ChatService {
             response.append("📝 ").append(mcpContext);
         }
         
-        response.append(String.format("\n\n💡 *Información proporcionada por %s*", serverName));
+        response.append(String.format("\n\n💡 *Information provided by %s*", serverName));
         return response.toString();
     }
 
@@ -327,7 +327,7 @@ public class ChatService {
             throw new IllegalStateException("Server is not connected: " + server.getName() + errorDetails + ". Use the connection button in the server list to connect.");
         }
 
-        // Detectar conexión inicial (mensaje vacío) y retornar herramientas disponibles
+        // Detect initial connection (empty message) and return available tools
         String query = request.getMessage();
         if (query == null || query.trim().isEmpty()) {
             return createInitialConnectionMessage(request, server);
@@ -351,11 +351,11 @@ public class ChatService {
         } else if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
             assistantContent = sendMessageViaHttp(server, request.getMessage());
         } else {
-            // Fallback al LLM local
+            // Fallback to local LLM
             ChatMessage contextMessage = ChatMessage.builder()
                     .id(UUID.randomUUID().toString())
                     .role("SYSTEM")
-                    .content("Contexto no implementado todavía")
+                    .content("Context not implemented yet")
                     .timestamp(System.currentTimeMillis())
                     .serverId(request.getServerId())
                     .build();
@@ -398,14 +398,14 @@ public class ChatService {
                 return "Error: STDIO process not available";
             }
 
-            // Determinar la herramienta apropiada basada en el mensaje
+            // Determine the appropriate tool based on the message
             String toolName = mcpToolService.selectBestTool(message, server);
             Map<String, Object> toolArgs = mcpToolService.extractToolArguments(message, toolName);
 
-            // Usar tools/call con la herramienta seleccionada
+            // Use tools/call with the selected tool
             String response = mcpToolService.callToolViaStdio(stdin, stdout, toolName, toolArgs);
 
-            log.info("Respuesta stdio de {}: {}", server.getName(), response);
+            log.info("Stdio response from {}: {}", server.getName(), response);
             if (response == null) {
                 return "Error: No response from MCP server";
             }
@@ -416,33 +416,33 @@ public class ChatService {
                 } else if (root.has("error")) {
                     return "Error MCP: " + root.get("error").toString();
                 } else {
-                    return "Respuesta inesperada del MCP server: " + response;
+                    return "Unexpected response from MCP server: " + response;
                 }
             } catch (Exception parseException) {
                 log.warn("Could not parse MCP response as JSON: {}", response);
                 return response; // Return raw response if not JSON
             }
         } catch (Exception e) {
-            log.error("Error comunicando por stdio: {}", e.getMessage(), e);
-            return "Error comunicando con el MCP server por stdio: " + e.getMessage();
+            log.error("Error communicating via stdio: {}", e.getMessage(), e);
+            return "Error communicating with the MCP server via stdio: " + e.getMessage();
         }
     }
 
     private String sendMessageViaHttp(McpServer server, String message) {
         try {
-            // Obtener herramientas disponibles dinámicamente
+            // Retrieve available tools dynamically
             List<Map<String, Object>> availableTools = mcpToolService.getTools(server);
-            log.debug("Herramientas disponibles en {}: {}", server.getName(), availableTools);
+            log.debug("Available tools on {}: {}", server.getName(), availableTools);
 
-            // Seleccionar la mejor herramienta
+            // Select the best tool
             String selectedTool = mcpToolService.selectBestTool(message, server);
-            log.debug("Herramienta seleccionada para '{}': {}", message, selectedTool);
+            log.debug("Selected tool for '{}': {}", message, selectedTool);
 
-            // Extraer argumentos para la herramienta
+            // Extract arguments for the tool
             Map<String, Object> toolArgs = mcpToolService.extractToolArguments(message, selectedTool);
-            log.debug("Argumentos extraídos: {}", toolArgs);
+            log.debug("Extracted arguments: {}", toolArgs);
 
-            // Usar tools/call con la herramienta seleccionada
+            // Use tools/call with the selected tool
             String response = mcpToolService.callToolViaHttp(server, selectedTool, toolArgs);
 
             JsonNode root = objectMapper.readTree(response);
@@ -451,11 +451,11 @@ public class ChatService {
             } else if (root.has("error")) {
                 return "Error MCP: " + root.get("error").toString();
             } else {
-                return "Respuesta inesperada del MCP server: " + response;
+                return "Unexpected response from MCP server: " + response;
             }
         } catch (Exception e) {
-            log.error("Error comunicando por HTTP: {}", e.getMessage(), e);
-            return "Error comunicando con el MCP server por HTTP: " + e.getMessage();
+            log.error("Error communicating via HTTP: {}", e.getMessage(), e);
+            return "Error communicating with the MCP server via HTTP: " + e.getMessage();
         }
     }
 }

--- a/backend/src/main/java/org/shark/mentor/mcp/service/LlmServiceEnhanced.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/LlmServiceEnhanced.java
@@ -110,21 +110,21 @@ public class LlmServiceEnhanced implements LlmService {
      */
     private String buildContextPrompt(String context, String question) {
         StringBuilder prompt = new StringBuilder();
-        prompt.append("CONTEXTO DEL SERVIDOR MCP:\n");
+        prompt.append("MCP SERVER CONTEXT:\n");
         prompt.append(context);
-        prompt.append("\n\nINSTRUCCIONES ESPECÍFICAS DE FORMATO:\n");
-        
+        prompt.append("\n\nSPECIFIC FORMATTING INSTRUCTIONS:\n");
+
 
             prompt.append("""
-                Organiza la información de forma clara con:
-                - Títulos descriptivos con emojis apropiados
-                - Información estructurada en listas
-                - Uso de markdown para dar formato
-                - Separación clara entre elementos
+                Organize the information clearly with:
+                - Descriptive titles with appropriate emojis
+                - Information structured in lists
+                - Use of markdown for formatting
+                - Clear separation between elements
                 """);
 
-        
-        prompt.append("\nTermina siempre con: 💡 *Información proporcionada por [nombre del servidor]*");
+
+        prompt.append("\nAlways end with: 💡 *Information provided by [server name]*");
         return prompt.toString();
     }
 
@@ -133,33 +133,33 @@ public class LlmServiceEnhanced implements LlmService {
      */
     private String buildSystemPrompt() {
         return """
-            Eres un asistente útil que trabaja con servidores MCP (Model Context Protocol).
-            
-            Pautas importantes:
-            1. Responde ÚNICAMENTE usando información proporcionada en el contexto de los servidores MCP
-            2. No inferir o agregar información que no esté explícitamente indicada en el contexto
-            3. Si el contexto es insuficiente para responder la pregunta, indica claramente qué información falta
-            4. Sé preciso y factual en tus respuestas
-            5. Cuando sea relevante, menciona qué servidor MCP proporcionó la información
-            6. SIEMPRE responde en español, independientemente del idioma de la pregunta
-            
-            FORMATO DE RESPUESTA:
-            - Usa títulos y subtítulos claros con emojis apropiados
-            - Para películas: 🎬 título, 📅 año, ⭐ calificación, 📝 descripción
-            - Para archivos: 📁 nombre, 📏 tamaño, 📅 fecha
-            - Para código/GitHub: 💻 repositorio, 🔧 función, 📊 estado
-            - Organiza la información en listas numeradas o con viñetas
-            - Usa espaciado adecuado entre secciones
-            - Si hay múltiples resultados, enuméralos claramente
-            
-            Ejemplo para películas:
-            🎬 **[Título de la película]** (📅 Año)
-            ⭐ Calificación: X.X/10
-            📝 **Sinopsis:** [Descripción]
-            🎭 **Género:** [Género]
-            
-            Siempre mantén la precisión y transparencia sobre las limitaciones del contexto disponible.
-            Todas las respuestas deben ser en español y bien formateadas.
+            You are a helpful assistant that works with MCP (Model Context Protocol) servers.
+
+            Important guidelines:
+            1. Respond ONLY using information provided in the context of MCP servers
+            2. Do not infer or add information that is not explicitly indicated in the context
+            3. If the context is insufficient to answer the question, clearly state what information is missing
+            4. Be precise and factual in your responses
+            5. When relevant, mention which MCP server provided the information
+            6. ALWAYS respond in English, regardless of the language of the question
+
+            RESPONSE FORMAT:
+            - Use clear titles and subtitles with appropriate emojis
+            - For movies: 🎬 title, 📅 year, ⭐ rating, 📝 description
+            - For files: 📁 name, 📏 size, 📅 date
+            - For code/GitHub: 💻 repository, 🔧 function, 📊 status
+            - Organize information in numbered or bulleted lists
+            - Use proper spacing between sections
+            - If there are multiple results, list them clearly
+
+            Example for movies:
+            🎬 **[Movie Title]** (📅 Year)
+            ⭐ Rating: X.X/10
+            📝 **Synopsis:** [Description]
+            🎭 **Genre:** [Genre]
+
+            Always maintain accuracy and transparency about the limitations of the available context.
+            All responses must be in English and well formatted.
             """;
     }
 }

--- a/backend/src/main/java/org/shark/mentor/mcp/service/McpServerService.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/McpServerService.java
@@ -97,7 +97,7 @@ public class McpServerService {
     }
 
     private void initializeSampleServers() {
-        // Este método ya no es necesario - se mantiene solo como fallback
+        // This method is no longer necessary - retained only as fallback
         log.info("Using fallback sample servers");
 
         addServer(new McpServer("sample-server", "Sample MCP Server",
@@ -189,7 +189,7 @@ public class McpServerService {
 
 
     private McpServer connectStdio(McpServer server) {
-        log.info("Conectando vía stdio a: {}", server.getName());
+        log.info("Connecting via stdio to: {}", server.getName());
         Process existing = stdioProcesses.get(server.getId());
 
         try {
@@ -201,20 +201,20 @@ public class McpServerService {
                 }
                 startStdioProcess(server);
             } else {
-                log.info("Reutilizando proceso stdio existente para {}", server.getName());
+                log.info("Reusing existing stdio process for {}", server.getName());
             }
 
             server.setStatus("CONNECTED");
             server.setLastConnected(System.currentTimeMillis());
             server.setLastError(null);
-            log.info("Conexión stdio establecida con {}", server.getName());
+            log.info("Stdio connection established with {}", server.getName());
         } catch (Exception e) {
             String errorMsg = e.getClass().getSimpleName() + ": " + (e.getMessage() != null ? e.getMessage() : "Connection failed");
-            log.error("Error conectando stdio a {}: {}", server.getName(), errorMsg, e);
+            log.error("Error connecting stdio to {}: {}", server.getName(), errorMsg, e);
             server.setStatus("ERROR");
             server.setLastConnected(System.currentTimeMillis());
             server.setLastError(errorMsg);
-            throw new RuntimeException("Fallo conexión stdio: " + errorMsg);
+            throw new RuntimeException("Stdio connection failure: " + errorMsg);
         }
         return server;
     }
@@ -222,7 +222,7 @@ public class McpServerService {
     private void startStdioProcess(McpServer server) throws IOException {
         String command = server.getUrl().substring("stdio://".length()).trim();
         if (command.isEmpty()) {
-            throw new RuntimeException("Comando stdio vacío");
+            throw new RuntimeException("Empty stdio command");
         }
 
         String[] parts = command.split("\\s+");
@@ -238,7 +238,7 @@ public class McpServerService {
         if (stdout.available() > 0) {
             BufferedReader reader = new BufferedReader(new InputStreamReader(stdout));
             String firstLine = reader.readLine();
-            log.info("Primer output stdio: {}", firstLine);
+            log.info("First stdio output: {}", firstLine);
         } else {
             log.debug("STDIO server started without initial output");
         }
@@ -248,7 +248,7 @@ public class McpServerService {
         log.info("Attempting HTTP connection to: {}", server.getUrl());
 
         try {
-            // Intentar primero /mcp/health, luego la raíz y otros endpoints si falla
+            // Attempt /mcp/health first, then the root and other endpoints if it fails
             String healthUrl = server.getUrl() + "/mcp/health";
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(healthUrl))
@@ -263,7 +263,7 @@ public class McpServerService {
                 server.setStatus("CONNECTED");
                 server.setLastError(null);
             } else if (response.statusCode() == 404 || response.statusCode() == 405 || response.statusCode() == 400) {
-                // Si /mcp/health no existe o no permite GET, intentar la raíz
+                // If /mcp/health does not exist or does not allow GET, try the root
                 log.info("Health endpoint not found, trying root endpoint for {}", server.getUrl());
                 HttpRequest rootRequest = HttpRequest.newBuilder()
                         .uri(URI.create(server.getUrl()))
@@ -278,7 +278,7 @@ public class McpServerService {
                     server.setStatus("CONNECTED");
                     server.setLastError(null);
                 } else if (rootResponse.statusCode() == 404 || rootResponse.statusCode() == 405) {
-                    // Si la raíz tampoco existe o no permite GET, intentar un endpoint funcional
+                    // If the root also does not exist or does not allow GET, try a functional endpoint
                     log.info("Root endpoint returned {} , trying tools list endpoint for {}", rootResponse.statusCode(), server.getUrl());
                     String toolsUrl = server.getUrl() + "/mcp/tools/list";
                     String body = String.format("{\"jsonrpc\":\"2.0\",\"id\":\"%s\",\"method\":\"tools/list\",\"params\":{}}", UUID.randomUUID());
@@ -395,7 +395,7 @@ public class McpServerService {
                 .map(server -> "CONNECTED".equals(server.getStatus()))
                 .orElse(false);
     }
-    // Agrega estos métodos públicos en McpServerService.java
+    // Add these public methods in McpServerService.java
 
     public Process getStdioProcess(String serverId) {
         return stdioProcesses.get(serverId);

--- a/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
@@ -29,7 +29,7 @@ public class McpToolOrchestrator {
     private final McpToolService mcpToolService;
 
     /**
-     * Ejecuta una tool MCP según el mensaje del usuario
+     * Executes an MCP tool based on the user's message
      */
     public String executeTool(McpServer server, String userMessage) {
         try {
@@ -38,13 +38,13 @@ public class McpToolOrchestrator {
 
             if (availableTools.isEmpty()) {
                 log.warn("No tools available for server: {}", server.getName());
-                return "No hay herramientas disponibles en el servidor MCP seleccionado.";
+                return "There are no tools available on the selected MCP server.";
             }
 
-            // Selecciona la mejor tool (puedes usar la lógica de McpToolService o aquí)
+            // Select the best tool (you can use the logic from McpToolService or here)
             String toolName = mcpToolService.selectBestTool(userMessage, server);
             if (toolName == null) {
-                return "No se pudo determinar la herramienta adecuada para tu solicitud.";
+                return "Unable to determine the appropriate tool for your request.";
             }
             Map<String, Object> toolSchema = availableTools.stream()
                     .filter(t -> toolName.equals(t.get("name")))
@@ -58,8 +58,8 @@ public class McpToolOrchestrator {
             return executeSelectedTool(server, toolName, arguments);
 
         } catch (Exception e) {
-            log.error("Error ejecutando tool MCP para el servidor {}: {}", server.getName(), e.getMessage(), e);
-            return "Error ejecutando la herramienta: " + e.getMessage();
+            log.error("Error executing MCP tool for server {}: {}", server.getName(), e.getMessage(), e);
+            return "Error executing the tool: " + e.getMessage();
         }
     }
 
@@ -70,7 +70,7 @@ public class McpToolOrchestrator {
             OutputStream stdin = mcpServerService.getStdioInput(server.getId());
             InputStream stdout = mcpServerService.getStdioOutput(server.getId());
             if (stdin == null || stdout == null) {
-                throw new IllegalStateException("STDIO streams no disponibles para el servidor: " + server.getId());
+                throw new IllegalStateException("STDIO streams not available for server: " + server.getId());
             }
             return mcpToolService.callToolViaStdio(stdin, stdout, toolName, arguments);
         } else {

--- a/backend/src/main/resources/mcp-servers.json
+++ b/backend/src/main/resources/mcp-servers.json
@@ -4,7 +4,7 @@
     {
       "id": "melian-local",
       "name": "Melian MCP Server (Local)",
-      "description": "Local MELIAN - Módulo de Embedding y Lógica Inteligente para Acceso Natural",
+      "description": "Local MELIAN - Embedding Module and Intelligent Logic for Natural Access",
       "url": "http://localhost:8080",
       "implemented": true
     },
@@ -20,7 +20,7 @@
     {
       "id": "polenta-local",
       "name": "Polenta MCP Server (Local)",
-      "description": "Servidor Polenta MCP para acceso al Data Lake con PrestoDB",
+      "description": "Polenta MCP Server for Data Lake access with PrestoDB",
       "url": "http://localhost:8090",
       "implemented": true,
       "prewarm": true

--- a/backend/src/test/java/org/shark/mentor/mcp/service/McpComplianceTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/McpComplianceTest.java
@@ -51,7 +51,7 @@ class McpComplianceTest {
                 .status("CONNECTED")
                 .build();
 
-        // Simula que no hay tools disponibles
+        // Simulate no tools available
         when(mcpToolService.getTools(server)).thenReturn(Collections.emptyList());
 
         // When executing a tool
@@ -60,7 +60,7 @@ class McpComplianceTest {
         // Then it should handle MCP protocol appropriately
         assertNotNull(result);
         // The orchestrator should gracefully handle when tools are not available
-        assertTrue(result.contains("No hay herramientas disponibles") || result.contains("Error"));
+        assertTrue(result.contains("There are no tools") || result.contains("Error"));
     }
 
     @Test
@@ -72,13 +72,13 @@ class McpComplianceTest {
                 .status("CONNECTED")
                 .build();
 
-        // Simula que getTools lanza una excepción
+        // Simulate getTools throwing an exception
         when(mcpToolService.getTools(server)).thenThrow(new RuntimeException("Simulated error"));
 
         String result = orchestrator.executeTool(server, "list repositories");
 
         // Then it should handle errors gracefully
         assertNotNull(result);
-        assertTrue(result.contains("Error") || result.contains("No tools") || result.contains("No hay herramientas disponibles"));
+        assertTrue(result.contains("Error") || result.contains("No tools") || result.contains("There are no tools"));
     }
 }

--- a/backend/src/test/java/org/shark/mentor/mcp/service/ResponseFormattingTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/ResponseFormattingTest.java
@@ -30,7 +30,7 @@ class ResponseFormattingTest {
               "title": "Thor",
               "year": "2011",
               "rating": "6.77",
-              "description": "Un poderoso pero arrogante dios guerrero",
+              "description": "A powerful but arrogant warrior god",
               "genre": "Action, Adventure, Fantasy"
             }
           ]
@@ -67,19 +67,19 @@ class ResponseFormattingTest {
 
     @Test
     void testFormattingImprovement() {
-        String uglyResponse = "Según el servidor MCP, hay múltiples películas con el título \"Thor\": * **Thor** (2011-04-21): Un poderoso pero arrogante dios guerrero, Thor, desciende a la Tierra como castigo";
-        
+        String uglyResponse = "According to the MCP server, there are multiple movies with the title \"Thor\": * **Thor** (2011-04-21): A powerful but arrogant warrior god, Thor, is banished to Earth as punishment";
+
         String improvedResponse = """
-        ✅ **Respuesta de Servidor de Películas**
-        
-        🎬 **Películas encontradas para "thor":**
-        
+        ✅ **Response from Movie Server**
+
+        🎬 **Movies found for "thor":**
+
         **1. Thor** (📅 2011)
-        ⭐ **Calificación:** 6.77/10
-        🎭 **Género:** Action, Adventure, Fantasy
-        📝 **Sinopsis:** Un poderoso pero arrogante dios guerrero
-        
-        💡 *Información proporcionada por Servidor de Películas*
+        ⭐ **Rating:** 6.77/10
+        🎭 **Genre:** Action, Adventure, Fantasy
+        📝 **Synopsis:** A powerful but arrogant warrior god
+
+        💡 *Information provided by Movie Server*
         """;
 
         // Verify improvement metrics

--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -58,15 +58,15 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
 
   useEffect(() => {
     if (!selectedServer) return;
-    console.log(`[ChatInterface] Cargando tools para ${selectedServer.id}`);
-    // Cargar tools del servidor seleccionado
+    console.log(`[ChatInterface] Loading tools for ${selectedServer.id}`);
+    // Load tools from the selected server
     getServerTools(selectedServer.id)
       .then((loadedTools) => {
-        console.log(`[ChatInterface] Tools cargadas para ${selectedServer.id}`, loadedTools);
+        console.log(`[ChatInterface] Tools loaded for ${selectedServer.id}`, loadedTools);
         setTools(loadedTools);
       })
       .catch((err) => {
-        console.error(`[ChatInterface] Error cargando tools para ${selectedServer.id}`, err);
+        console.error(`[ChatInterface] Error loading tools for ${selectedServer.id}`, err);
         setTools([]);
       });
     loadConversation();
@@ -106,7 +106,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
       toast.current?.show({
         severity: 'error',
         summary: 'Error',
-        detail: 'Error al enviar mensaje',
+        detail: 'Error sending message',
         life: 3000,
       });
     } finally {
@@ -120,15 +120,15 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
       setMessages([]);
       toast.current?.show({
         severity: 'success',
-        summary: 'Limpiado',
-        detail: 'Conversación limpiada',
+        summary: 'Cleared',
+        detail: 'Conversation cleared',
         life: 2000,
       });
     } catch (error) {
       toast.current?.show({
         severity: 'error',
         summary: 'Error',
-        detail: 'Error al limpiar conversación',
+        detail: 'Error clearing conversation',
         life: 3000,
       });
     }
@@ -164,7 +164,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
           <div className="chat-message-content">
             <div className="chat-message-header">
             <span className="chat-message-role">
-              {isUser ? 'Tú' : selectedServer?.name || 'Asistente'}
+              {isUser ? 'You' : selectedServer?.name || 'Assistant'}
             </span>
               <span className="chat-message-time">
               {formatTimestamp(message.timestamp)}
@@ -206,13 +206,13 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
             <i className="pi pi-comments" style={{ fontSize: '3rem', color: '#ccc' }} />
             {!selectedServer ? (
                 <>
-                  <h3>Selecciona un Servidor MCP</h3>
-                  <p>Elige un servidor MCP del panel izquierdo para comenzar a chatear</p>
+                  <h3>Select an MCP Server</h3>
+                    <p>Select an MCP server from the left panel to start chatting</p>
                 </>
             ) : (
                 <>
-                  <h3>Servidor No Conectado</h3>
-                  <p>El servidor seleccionado "{selectedServer.name}" no está conectado. Por favor, conecta al servidor primero.</p>
+                  <h3>Server Not Connected</h3>
+                  <p>The selected server "{selectedServer.name}" is not connected. Please connect the server first.</p>
                 </>
             )}
           </div>
@@ -220,15 +220,15 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
     );
   }
 
-  // Si el servidor está conectado pero las herramientas no han sido reconocidas
+  // If the server is connected but the tools have not been acknowledged
   if (!toolsAcknowledged) {
     return (
         <div className="chat-interface-empty">
           <div className="chat-empty-content">
             <ProgressSpinner style={{width: '3rem', height: '3rem'}} strokeWidth="4" animationDuration="1s" />
-            <h3>Revisando Herramientas del Servidor</h3>
-            <p>Mostrando las herramientas disponibles en "{selectedServer.name}"...</p>
-            <p><small>El chat se habilitará después de revisar las herramientas.</small></p>
+              <h3>Reviewing Server Tools</h3>
+              <p>Showing the available tools on "{selectedServer.name}"...</p>
+            <p><small>The chat will be enabled after reviewing the tools.</small></p>
           </div>
         </div>
     );
@@ -254,7 +254,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
                   {/* Mostrar tools del servidor */}
                   {tools.length > 0 && (
                     <div className="chat-server-tools">
-                      <strong>Herramientas disponibles:</strong>
+                      <strong>Available tools:</strong>
                       <ul>
                         {tools.map(tool => (
                           <li key={tool.name}>
@@ -283,7 +283,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
               {messages.length === 0 ? (
                   <div className="chat-welcome">
                     <h4>Bienvenido a {selectedServer.name}</h4>
-                    <p>Comienza una conversación escribiendo un mensaje abajo.</p>
+                    <p>Start a conversation by typing a message below.</p>
                   </div>
               ) : (
                   messages.map(renderMessage)
@@ -309,7 +309,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
                   value={inputMessage}
                   onChange={(e) => setInputMessage(e.target.value)}
                   onKeyDown={handleKeyPress}
-                  placeholder={`Escribe tu mensaje para ${selectedServer.name}... (Enter para enviar, Shift+Enter para nueva línea)`}
+                  placeholder={`Type your message to ${selectedServer.name}... (Enter to send, Shift+Enter for new line)`}
                   className="chat-input-field"
                   disabled={loading || selectedServer.status !== 'CONNECTED' || !toolsAcknowledged}
                   rows={3}

--- a/ui/src/components/McpServerList.jsx
+++ b/ui/src/components/McpServerList.jsx
@@ -116,7 +116,7 @@ export const McpServerList = ({ onServerSelect, selectedServerId, onServersUpdat
       const response = await mcpServerService.connectToServer(server.id);
       console.log('🌐 Response from connectToServer:', response);
 
-      // Evaluar estado de conexión devuelto por el backend
+      // Evaluate connection status returned by the backend
       if (response.status === 'CONNECTED') {
         toast.current?.show({
           severity: 'success',

--- a/ui/src/components/ToolsModal.jsx
+++ b/ui/src/components/ToolsModal.jsx
@@ -11,7 +11,7 @@ export const ToolsModal = ({ visible, onHide, tools, serverName }) => {
   const footer = (
     <div>
       <Button
-        label="Continuar al Chat"
+        label="Continue to Chat"
         icon="pi pi-check"
         onClick={handleContinue}
         className="p-button-success"
@@ -23,7 +23,7 @@ export const ToolsModal = ({ visible, onHide, tools, serverName }) => {
     <Dialog
       visible={visible}
       onHide={onHide}
-      header={`Herramientas disponibles en ${serverName}`}
+      header={`Available tools in ${serverName}`}
       footer={footer}
       style={{ width: '70vw', maxWidth: '800px' }}
       maximizable
@@ -32,13 +32,13 @@ export const ToolsModal = ({ visible, onHide, tools, serverName }) => {
     >
       <div className="tools-modal-content">
         <p className="tools-modal-description">
-          Este servidor MCP expone las siguientes herramientas que podrás usar en el chat:
+          This MCP server exposes the following tools you can use in the chat:
         </p>
         
         {tools.length === 0 ? (
           <div className="tools-empty-state">
             <i className="pi pi-info-circle" style={{ fontSize: '2rem', color: '#ccc' }} />
-            <p>No se encontraron herramientas disponibles en este servidor.</p>
+            <p>No tools available on this server.</p>
           </div>
         ) : (
           <div className="tools-grid">
@@ -52,11 +52,11 @@ export const ToolsModal = ({ visible, onHide, tools, serverName }) => {
                 </div>
                 <div className="tool-content">
                   <p className="tool-description">
-                    {tool.description || 'Sin descripción disponible'}
+                    {tool.description || 'No description available'}
                   </p>
                   {tool.inputSchema && tool.inputSchema.properties && (
                     <div className="tool-parameters">
-                      <strong>Parámetros:</strong>
+                      <strong>Parameters:</strong>
                       <ul>
                         {Object.entries(tool.inputSchema.properties).map(([paramName, paramInfo]) => (
                           <li key={paramName}>

--- a/ui/src/components/ui/QuizModal.jsx
+++ b/ui/src/components/ui/QuizModal.jsx
@@ -30,7 +30,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
         if (editMode && initialData) {
             setQuizTitle(initialData.tema || "");
             setQuizPrompt(initialData.prompt || "");
-            
+
             if (initialData.steps && initialData.steps.length > 0) {
                 const formattedQuestions = initialData.steps.map((step, index) => ({
                     id: parseInt(step.id) || index + 1,
@@ -147,8 +147,8 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
     };
 
     return (
-        <Dialog 
-            header={`${editMode ? 'Editar' : 'Crear'} Quiz ${quizTitle ? `- ${quizTitle}` : ''}`}
+        <Dialog
+            header={`${editMode ? 'Edit' : 'Create'} Quiz ${quizTitle ? `- ${quizTitle}` : ''}`}
             visible={visible} 
             onHide={handleClose} 
             modal 
@@ -157,32 +157,32 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
             style={{ width: '50vw', minWidth: '400px', height: '700px' }}
         >
             <div className="quiz-content">
-                {/* Título del Quiz */}
+                {/* Quiz Title */}
                 <div className="quiz-title-section">
                     <label htmlFor="quiz-title" className="quiz-title-label">
                         <i className="pi pi-bookmark" style={{ marginRight: '0.5rem' }}></i>
-                        Título del Quiz
+                        Quiz Title
                     </label>
                     <InputField
                         id="quiz-title"
                         value={quizTitle}
                         onChange={(e) => setQuizTitle(e.target.value)}
-                        placeholder="Ingresa el título de tu quiz..."
+                        placeholder="Enter the title of your quiz..."
                         className="quiz-title-input"
                     />
                 </div>
 
-                {/* Prompt del Quiz */}
+                {/* Quiz Prompt */}
                 <div className="quiz-prompt-section">
                     <label htmlFor="quiz-prompt" className="quiz-prompt-label">
                         <i className="pi pi-comments" style={{ marginRight: '0.5rem' }}></i>
-                        Prompt para LLM (opcional)
+                        LLM Prompt (optional)
                     </label>
                     <textarea
                         id="quiz-prompt"
                         value={quizPrompt}
                         onChange={(e) => setQuizPrompt(e.target.value)}
-                        placeholder={defaultPrompt || "Ingresa el prompt que se usará para evaluar las respuestas con el LLM..."}
+                        placeholder={defaultPrompt || "Enter the prompt that will be used to evaluate the answers with the LLM..."}
                         className="quiz-prompt-input"
                         rows="3"
                     />
@@ -190,13 +190,13 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                 {questions.map((question, index) => (
                     <div key={question.id} className="question-item">
                         <div className="question-header">
-                            <p className="question-label">Pregunta número {index + 1}</p>
+                            <p className="question-label">Question number {index + 1}</p>
                             {questions.length > 1 && (
                                 <Button 
                                     icon="pi pi-trash" 
                                     className="p-button-rounded p-button-text p-button-danger p-button-sm"
                                     onClick={() => removeQuestion(question.id)}
-                                    tooltip="Eliminar pregunta"
+                                    tooltip="Remove question"
                                     tooltipOptions={{ position: 'top' }}
                                 />
                             )}
@@ -204,7 +204,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                         <InputField 
                             value={question.value}
                             onChange={(e) => updateQuestion(question.id, e.target.value)}
-                            placeholder={`Ingresa la pregunta ${index + 1}...`}
+                            placeholder={`Enter question ${index + 1}...`}
                             className="question-input"
                         />
                         
@@ -218,22 +218,22 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                                     className="random-checkbox"
                                 />
                                 <i className="pi pi-refresh" style={{ marginLeft: '0.5rem', marginRight: '0.5rem' }}></i>
-                                Ordenar opciones aleatoriamente
+                                Shuffle options randomly
                             </label>
                         </div>
                         
                         {/* Options section */}
                         <div className="question-options">
                             <div className="options-header">
-                                <label className="options-label">
+                                    <label className="options-label">
                                     <i className="pi pi-list" style={{ marginRight: '0.5rem' }}></i>
-                                    Opciones de respuesta
+                                    Answer options
                                 </label>
                                 <Button
                                     icon="pi pi-plus"
                                     className="p-button-rounded p-button-text p-button-sm"
                                     onClick={() => addOption(question.id)}
-                                    tooltip="Agregar opción"
+                                    tooltip="Add option"
                                     tooltipOptions={{ position: 'top' }}
                                 />
                             </div>
@@ -242,7 +242,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                                     <InputField
                                         value={option}
                                         onChange={(e) => updateOption(question.id, optionIndex, e.target.value)}
-                                        placeholder={`Opción ${optionIndex + 1}...`}
+                                        placeholder={`Option ${optionIndex + 1}...`}
                                         className="option-input"
                                     />
                                     {question.options.length > 1 && (
@@ -250,7 +250,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                                             icon="pi pi-times"
                                             className="p-button-rounded p-button-text p-button-danger p-button-sm"
                                             onClick={() => removeOption(question.id, optionIndex)}
-                                            tooltip="Eliminar opción"
+                                            tooltip="Remove option"
                                             tooltipOptions={{ position: 'top' }}
                                         />
                                     )}
@@ -263,7 +263,7 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                 <div className="add-question-section">
                     <Button
                         icon="pi pi-plus"
-                        label={`Agregar Pregunta ${questions.length < MAX_QUESTIONS ? `(${MAX_QUESTIONS - questions.length} restantes)` : ''}`}
+                        label={`Add Question ${questions.length < MAX_QUESTIONS ? `(${MAX_QUESTIONS - questions.length} remaining)` : ''}`}
                         className="p-button-outlined"
                         onClick={addQuestion}
                         disabled={questions.length >= MAX_QUESTIONS}
@@ -271,20 +271,20 @@ export const QuizModal = ({ visible, onHide, onSave, editMode = false, initialDa
                     {questions.length >= MAX_QUESTIONS && (
                         <small className="max-questions-warning">
                             <i className="pi pi-info-circle" style={{ marginRight: '0.25rem' }}></i>
-                            Máximo {MAX_QUESTIONS} preguntas permitidas
+                            Maximum {MAX_QUESTIONS} questions allowed
                         </small>
                     )}
                 </div>
 
                 <div className="modal-footer">
                     <Button
-                        label="Cancelar"
+                        label="Cancel"
                         icon="pi pi-times"
                         className="p-button-outlined"
                         onClick={handleClose}
                     />
                     <Button
-                        label={editMode ? "Actualizar" : "Guardar"}
+                        label={editMode ? "Update" : "Save"}
                         icon="pi pi-check"
                         className="p-button-primary"
                         severity="success" // Cambiado para mejor visibilidad

--- a/ui/src/pages/McpClientApp.jsx
+++ b/ui/src/pages/McpClientApp.jsx
@@ -18,7 +18,7 @@ const McpClientApp = () => {
   const handleServerSelect = async (server) => {
     setSelectedServer(server);
     
-    // Si el servidor está conectado y no hemos mostrado las herramientas aún
+    // If the server is connected and we haven't shown the tools yet
     if (server.status === 'CONNECTED' && !toolsAcknowledged.has(server.id)) {
       try {
         console.log('Fetching tools for first-time server selection:', server.name);
@@ -27,7 +27,7 @@ const McpClientApp = () => {
         setShowToolsModal(true);
       } catch (error) {
         console.error('Error fetching tools:', error);
-        // Si no se pueden obtener las herramientas, marcar como reconocido para permitir el chat
+        // If tools cannot be fetched, mark as acknowledged to allow the chat
         setToolsAcknowledged(prev => new Set(prev).add(server.id));
       }
     }
@@ -36,7 +36,7 @@ const McpClientApp = () => {
   const handleToolsModalHide = () => {
     setShowToolsModal(false);
     if (selectedServer) {
-      // Marcar las herramientas como reconocidas para este servidor
+      // Mark the tools as acknowledged for this server
       setToolsAcknowledged(prev => new Set(prev).add(selectedServer.id));
     }
   };
@@ -44,7 +44,7 @@ const McpClientApp = () => {
   const handleServersUpdate = (updatedServers) => {
     setServers(updatedServers);
 
-    // Si hay un servidor seleccionado, actualízalo con los nuevos datos
+    // If a server is selected, update it with the new data
     if (selectedServer) {
       const updatedSelectedServer = updatedServers.find(s => s.id === selectedServer.id);
       if (updatedSelectedServer) {

--- a/ui/src/services/chatService.js
+++ b/ui/src/services/chatService.js
@@ -21,7 +21,7 @@ export const chatService = {
     const url = `${normalizeBaseUrl(baseUrl)}/chat/send`;
     const payload = { serverId, message, conversationId };
 
-    console.log('📤 Intentando enviar mensaje a:', url);
+    console.log('📤 Attempting to send message to:', url);
     console.log('📦 Payload:', JSON.stringify(payload, null, 2));
 
     try {
@@ -36,7 +36,7 @@ export const chatService = {
       console.log('📬 Raw response text:', responseText);
 
       if (!response.ok) {
-        console.error('❌ Respuesta con error HTTP:', response.status, responseText);
+        console.error('❌ HTTP error response:', response.status, responseText);
         throw new Error(`Failed to send message: HTTP ${response.status}`);
       }
 
@@ -45,7 +45,7 @@ export const chatService = {
 
       return parsed;
     } catch (err) {
-      console.error('🔥 Excepción al enviar mensaje:', err);
+      console.error('🔥 Exception sending message:', err);
       throw new Error('Failed to send message');
     }
   },

--- a/ui/src/services/toolService.js
+++ b/ui/src/services/toolService.js
@@ -2,21 +2,21 @@
 export async function getServerTools(serverId) {
   const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8083';
   const url = `${BACKEND_URL}/api/mcp/tools/${serverId}`;
-  console.log(`[toolService] Solicitando tools de ${url}`);
+  console.log(`[toolService] Requesting tools from ${url}`);
   const start = performance.now();
   try {
     const response = await fetch(url);
     if (!response.ok) {
-      console.error(`[toolService] Error en la solicitud a ${url}: ${response.status}`);
+      console.error(`[toolService] Request error to ${url}: ${response.status}`);
       throw new Error('Failed to fetch tools');
     }
     const data = await response.json();
     const elapsed = Math.round(performance.now() - start);
-    console.log(`[toolService] Tools recibidas de ${serverId} en ${elapsed}ms`, data);
+    console.log(`[toolService] Tools received from ${serverId} in ${elapsed}ms`, data);
     return data;
   } catch (error) {
     const elapsed = Math.round(performance.now() - start);
-    console.error(`[toolService] Falló la obtención de tools para ${serverId} después de ${elapsed}ms`, error);
+    console.error(`[toolService] Failed to fetch tools for ${serverId} after ${elapsed}ms`, error);
     throw error;
   }
 }

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -166,7 +166,7 @@
   }
 }
 
-/* Input del chat - posición inferior fija */
+/* Chat input - fixed bottom position */
 .chat-input {
   padding: 1rem;
   border-top: 1px solid #e0e0e0;
@@ -218,7 +218,7 @@
   cursor: not-allowed;
 }
 
-/* Estado vacío del chat */
+/* Empty chat state */
 .chat-interface-empty {
   height: 100%;
   display: flex;


### PR DESCRIPTION
## Summary
- Translate server configuration descriptions to English
- Convert backend prompts and chat service logs to English
- Update frontend UI text and tool dialogs to English

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6897646f8f64832e92d369b0f72c61f2