### PR TITLE
feat: modernize MCP server panel and spinner

### DIFF
--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -5,7 +5,7 @@ import { Button } from 'primereact/button';
 import { ScrollPanel } from 'primereact/scrollpanel';
 import { Toast } from 'primereact/toast';
 import { Avatar } from 'primereact/avatar';
-import { ProgressSpinner } from 'primereact/progressspinner';
+import sharkLogo from '../assets/shark-ia.png';
 import ReactMarkdown from 'react-markdown';
 import { chatService } from '../services/chatService';
 import { getServerTools } from '../services/toolService';
@@ -225,7 +225,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
     return (
         <div className="chat-interface-empty">
           <div className="chat-empty-content">
-            <ProgressSpinner style={{width: '3rem', height: '3rem'}} strokeWidth="4" animationDuration="1s" />
+            <img src={sharkLogo} alt="loading" className="shark-spinner" />
               <h3>Reviewing Server Tools</h3>
               <p>Showing the available tools on "{selectedServer.name}"...</p>
             <p><small>The chat will be enabled after reviewing the tools.</small></p>

--- a/ui/src/components/McpHeader.jsx
+++ b/ui/src/components/McpHeader.jsx
@@ -15,6 +15,7 @@ export const McpHeader = ({ onToggleSidebar, sidebarCollapsed }) => {  return (
         <h1 className="header-title">Mentor - Model Context Protocol Client Interface</h1>
       </div>
       <div className="header-info">
+        <i className="pi pi-globe header-web-icon" />
         <span className="header-info-text">No authentication required</span>
       </div>
     </header>

--- a/ui/src/pages/McpClientApp.jsx
+++ b/ui/src/pages/McpClientApp.jsx
@@ -3,6 +3,7 @@ import { McpHeader } from '../components/McpHeader';
 import { McpServerList } from '../components/McpServerList';
 import { ChatInterface } from '../components/ChatInterface';
 import { ToolsModal } from '../components/ToolsModal';
+import { Splitter, SplitterPanel } from 'primereact/splitter';
 import { getServerTools } from '../services/toolService';
 import '../styles/mcp-client-app.css';
 
@@ -10,6 +11,7 @@ const McpClientApp = () => {
   const [selectedServer, setSelectedServer] = useState(null);
   const [servers, setServers] = useState([]);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarSize, setSidebarSize] = useState(25);
   const [toolsAcknowledged, setToolsAcknowledged] = useState(new Set());
   const [showToolsModal, setShowToolsModal] = useState(false);
   const [currentTools, setCurrentTools] = useState([]);
@@ -57,19 +59,23 @@ const McpClientApp = () => {
       <div className="mcp-client-app">
         <McpHeader onToggleSidebar={toggleSidebar} sidebarCollapsed={sidebarCollapsed} />
         <div className="mcp-client-main">
-          <div className={`mcp-client-sidebar${sidebarCollapsed ? ' collapsed' : ''}`}>
-            <McpServerList
-                onServerSelect={handleServerSelect}
-                selectedServerId={selectedServer?.id}
-                onServersUpdate={handleServersUpdate}
-            />
-          </div>
-          <div className="mcp-client-chat">
-            <ChatInterface 
-              selectedServer={selectedServer} 
-              toolsAcknowledged={toolsAcknowledged.has(selectedServer?.id)}
-            />
-          </div>
+          <Splitter style={{ width: '100%', height: '100%' }} gutterSize={8} onResizeEnd={(e) => setSidebarSize(e.sizes[0])}>
+            <SplitterPanel size={sidebarCollapsed ? 0 : sidebarSize} minSize={10} className="mcp-client-sidebar" style={sidebarCollapsed ? { display: 'none' } : {}}>
+              {!sidebarCollapsed && (
+                <McpServerList
+                  onServerSelect={handleServerSelect}
+                  selectedServerId={selectedServer?.id}
+                  onServersUpdate={handleServersUpdate}
+                />
+              )}
+            </SplitterPanel>
+            <SplitterPanel size={sidebarCollapsed ? 100 : 100 - sidebarSize} className="mcp-client-chat">
+              <ChatInterface
+                selectedServer={selectedServer}
+                toolsAcknowledged={toolsAcknowledged.has(selectedServer?.id)}
+              />
+            </SplitterPanel>
+          </Splitter>
         </div>
         
         <ToolsModal

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -232,6 +232,17 @@
   color: #666;
 }
 
+.shark-spinner {
+  width: 3rem;
+  height: 3rem;
+  animation: shark-spin 1s linear infinite;
+}
+
+@keyframes shark-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 .chat-empty-content h3 {
   margin: 1rem 0 0.5rem 0;
   color: #333;

--- a/ui/src/styles/header.css
+++ b/ui/src/styles/header.css
@@ -51,6 +51,11 @@
     align-items: center;
 }
 
+.header-web-icon {
+    color: #fff;
+    margin-right: 0.5rem;
+}
+
 .header-info-text {
     color: #e5e7eb;
     font-size: 0.875rem;

--- a/ui/src/styles/mcp-client-app.css
+++ b/ui/src/styles/mcp-client-app.css
@@ -2,7 +2,7 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  background: #f8f9fa;
+  background: #f0f2f5;
 }
 
 .mcp-client-main {
@@ -12,20 +12,15 @@
 }
 
 .mcp-client-sidebar {
-  width: 350px;
-  min-width: 300px;
-  max-width: 500px;
   display: flex;
   flex-direction: column;
-  background: #f8f9fa;
+  background: #ffffff;
   border-right: 1px solid #e9ecef;
-  transition: width 0.3s ease;
   overflow: hidden;
 }
 
 .mcp-client-sidebar.collapsed {
-  width: 0;
-  min-width: 0;
+  display: none;
 }
 
 .mcp-client-chat {
@@ -33,6 +28,14 @@
   display: flex;
   flex-direction: column;
   background: #ffffff;
+}
+
+.p-splitter-gutter {
+  background: #e9ecef;
+}
+
+.p-splitter-gutter-handle {
+  background: #e9ecef;
 }
 
 /* Responsive design */

--- a/ui/src/styles/mcp-server-list.css
+++ b/ui/src/styles/mcp-server-list.css
@@ -2,7 +2,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #f8f9fa;
+  background: #ffffff;
   border-right: 1px solid #e9ecef;
 }
 


### PR DESCRIPTION
## Summary
- Make MCP server sidebar resizable and collapsible with PrimeReact Splitter
- Replace default spinner with rotating shark logo
- Harmonize UI colors and add web icon to header

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689768ca9cc8832ea0ea649809a705b9