### PR TITLE
fix: unify language directive for LLM responses

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/service/LlmServiceEnhanced.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/LlmServiceEnhanced.java
@@ -159,7 +159,7 @@ public class LlmServiceEnhanced implements LlmService {
             🎭 **Genre:** [Genre]
 
             Always maintain accuracy and transparency about the limitations of the available context.
-            All responses must be in English and well formatted.
+            All responses must be in Spanish and well formatted.
             """;
     }
 }

--- a/backend/src/test/java/org/shark/mentor/mcp/service/LlmServiceEnhancedTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/LlmServiceEnhancedTest.java
@@ -1,0 +1,46 @@
+package org.shark.mentor.mcp.service;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.*;
+
+class LlmServiceEnhancedTest {
+
+    @Test
+    void generateWithMemoryReturnsSpanishResponse() throws Exception {
+        LlmProperties props = new LlmProperties();
+        LlmServiceEnhanced service = new LlmServiceEnhanced(props);
+
+        ChatLanguageModel model = mock(ChatLanguageModel.class);
+        var captor = forClass(List.class);
+        when(model.generate(captor.capture())).thenAnswer(invocation -> {
+            List<ChatMessage> messages = invocation.getArgument(0);
+            String systemText = ((SystemMessage) messages.get(0)).text();
+            String content = systemText.contains("All responses must be in Spanish")
+                    ? "Respuesta en español" : "English response";
+            return Response.from(AiMessage.from(content));
+        });
+
+        Field field = LlmServiceEnhanced.class.getDeclaredField("chatModel");
+        field.setAccessible(true);
+        field.set(service, model);
+
+        String result = service.generateWithMemory("conv", "Hello", null);
+
+        assertEquals("Respuesta en español", result);
+        List<ChatMessage> messages = captor.getValue();
+        String systemText = ((SystemMessage) messages.get(0)).text();
+        assertTrue(systemText.contains("ALWAYS respond in Spanish"));
+        assertTrue(systemText.contains("All responses must be in Spanish"));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure LLM system prompt consistently requires Spanish responses
- add unit test verifying service yields Spanish text

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5422478832e815ee96ee32b2d31