### PR TITLE
Validate MCP tool arguments against schema

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
@@ -50,7 +50,8 @@ public class McpToolOrchestrator {
                     .filter(t -> toolName.equals(t.get("name")))
                     .findFirst()
                     .orElse(availableTools.get(0));
-            Map<String, Object> arguments = mcpToolService.extractToolArguments(userMessage, toolName);
+            Map<String, Object> arguments = mcpToolService.extractToolArguments(userMessage, toolName,
+                    (Map<String, Object>) toolSchema.get("inputSchema"));
 
             log.info("Selected tool '{}' for message: {}", toolName, userMessage);
 
@@ -72,7 +73,7 @@ public class McpToolOrchestrator {
             if (stdin == null || stdout == null) {
                 throw new IllegalStateException("STDIO streams not available for server: " + server.getId());
             }
-            return mcpToolService.callToolViaStdio(stdin, stdout, toolName, arguments);
+            return mcpToolService.callToolViaStdio(server, stdin, stdout, toolName, arguments);
         } else {
             return mcpToolService.callToolViaHttp(server, toolName, arguments);
         }


### PR DESCRIPTION
## Summary
- check tool arguments against their inputSchema before HTTP/stdio calls
- return structured errors for missing or mis-typed fields
- wire schema validation through ChatService and orchestrator

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for org.shark.mentor:mcp-client-backend:0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_6898d548e658832e9f20cedb1d6dec1c