### PR TITLE
feat: schedule MCP tools via LLM

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
@@ -1,20 +1,15 @@
 package org.shark.mentor.mcp.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.shark.mentor.mcp.model.McpServer;
 import org.springframework.stereotype.Service;
 
-import java.io.*;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.*;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Simplified MCP tool orchestrator using langchain4j principles
@@ -33,7 +28,6 @@ public class McpToolOrchestrator {
      */
     public String executeTool(McpServer server, String userMessage) {
         try {
-            // Obtiene las tools usando el servicio centralizado
             List<Map<String, Object>> availableTools = mcpToolService.getTools(server);
 
             if (availableTools.isEmpty()) {
@@ -41,29 +35,27 @@ public class McpToolOrchestrator {
                 return "There are no tools available on the selected MCP server.";
             }
 
-            // Select the best tool (you can use the logic from McpToolService or here)
-            String toolName = mcpToolService.selectBestTool(userMessage, server);
-            if (toolName == null) {
+            Map<String, Object> toolCall = mcpToolService.scheduleToolCall(userMessage, availableTools);
+            if (toolCall == null) {
                 return "Unable to determine the appropriate tool for your request.";
             }
-            Map<String, Object> toolSchema = availableTools.stream()
-                    .filter(t -> toolName.equals(t.get("name")))
-                    .findFirst()
-                    .orElse(availableTools.get(0));
-            Map<String, Object> arguments = mcpToolService.extractToolArguments(userMessage, toolName);
+
+            String toolName = Optional.ofNullable(toolCall.get("params"))
+                    .filter(Map.class::isInstance)
+                    .map(Map.class::cast)
+                    .map(p -> (String) p.get("name"))
+                    .orElse("unknown");
 
             log.info("Selected tool '{}' for message: {}", toolName, userMessage);
 
-            // Ejecuta la tool seleccionada
-            return executeSelectedTool(server, toolName, arguments);
-
+            return executeSelectedTool(server, toolCall);
         } catch (Exception e) {
             log.error("Error executing MCP tool for server {}: {}", server.getName(), e.getMessage(), e);
             return "Error executing the tool: " + e.getMessage();
         }
     }
 
-    private String executeSelectedTool(McpServer server, String toolName, Map<String, Object> arguments) throws Exception {
+    private String executeSelectedTool(McpServer server, Map<String, Object> toolCall) throws Exception {
         String protocol = extractProtocol(server.getUrl());
 
         if ("stdio".equalsIgnoreCase(protocol)) {
@@ -72,9 +64,9 @@ public class McpToolOrchestrator {
             if (stdin == null || stdout == null) {
                 throw new IllegalStateException("STDIO streams not available for server: " + server.getId());
             }
-            return mcpToolService.callToolViaStdio(stdin, stdout, toolName, arguments);
+            return mcpToolService.callToolViaStdio(stdin, stdout, toolCall);
         } else {
-            return mcpToolService.callToolViaHttp(server, toolName, arguments);
+            return mcpToolService.callToolViaHttp(server, toolCall);
         }
     }
 

--- a/backend/src/test/java/org/shark/mentor/mcp/service/McpToolSchedulerTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/McpToolSchedulerTest.java
@@ -1,0 +1,67 @@
+package org.shark.mentor.mcp.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class McpToolSchedulerTest {
+
+    @Mock
+    private McpServerService mcpServerService;
+
+    @Mock
+    private LlmService llmService;
+
+    private McpToolService mcpToolService;
+
+    @BeforeEach
+    void setUp() {
+        mcpToolService = new McpToolService(mcpServerService, llmService);
+    }
+
+    @Test
+    void scheduleToolCallProducesValidJsonRpc() throws Exception {
+        Map<String, Object> inputSchema = Map.of(
+                "type", "object",
+                "properties", Map.of("q", Map.of("type", "string")),
+                "required", List.of("q")
+        );
+        List<Map<String, Object>> tools = List.of(
+                Map.of("name", "search_repositories", "inputSchema", inputSchema)
+        );
+
+        String llmResponse = """
+        {
+          \"jsonrpc\": \"2.0\",
+          \"id\": \"1\",
+          \"method\": \"tools/call\",
+          \"params\": {\"name\": \"search_repositories\", \"arguments\": {\"q\": \"java\"}}
+        }
+        """;
+        when(llmService.generate(anyString(), anyString())).thenReturn(llmResponse);
+
+        Map<String, Object> call = mcpToolService.scheduleToolCall("find java repos", tools);
+
+        assertNotNull(call);
+        assertEquals("2.0", call.get("jsonrpc"));
+        assertEquals("tools/call", call.get("method"));
+        Map<String, Object> params = (Map<String, Object>) call.get("params");
+        assertEquals("search_repositories", params.get("name"));
+        Map<String, Object> args = (Map<String, Object>) params.get("arguments");
+        assertEquals("java", args.get("q"));
+
+        List<String> required = (List<String>) inputSchema.get("required");
+        for (String req : required) {
+            assertTrue(args.containsKey(req));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- delegate tool selection and argument extraction to an LLM-based scheduler
- allow `McpToolService` to send pre-built JSON-RPC calls over HTTP or stdio
- cover LLM planning with a unit test validating schema compliance

## Testing
- `mvn -q -e test` *(fails: 'dependencies.dependency.version' for org.testcontainers... is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898d54c3ba8832e933d7dea3863d0e5