### PR TITLE
feat(ui): add tool-based autocomplete in chat input

### DIFF
--- a/ui/src/components/ChatInterface.jsx
+++ b/ui/src/components/ChatInterface.jsx
@@ -16,6 +16,7 @@ const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8083/a
 export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => {
   const [messages, setMessages] = useState([]);
   const [inputMessage, setInputMessage] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [tools, setTools] = useState([]);
   const [infoCollapsed, setInfoCollapsed] = useState(false);
@@ -79,6 +80,28 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
     }
   }, [messages]);
 
+  const handleInputChange = (e) => {
+    const value = e.target.value;
+    setInputMessage(value);
+
+    const lastWord = value.split(/\s+/).pop();
+    if (lastWord) {
+      const matches = tools
+        .map((t) => t.name)
+        .filter((name) => name.toLowerCase().startsWith(lastWord.toLowerCase()));
+      setSuggestions(matches);
+    } else {
+      setSuggestions([]);
+    }
+  };
+
+  const handleSuggestionClick = (suggestion) => {
+    const words = inputMessage.split(/\s+/);
+    words[words.length - 1] = suggestion;
+    setInputMessage(words.join(' ') + ' ');
+    setSuggestions([]);
+  };
+
   const handleSendMessage = async () => {
     if (!inputMessage.trim() || !selectedServer || selectedServer.status !== 'CONNECTED' || !toolsAcknowledged || loading) return;
 
@@ -92,6 +115,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
 
     setMessages(prev => [...prev, userMessage]);
     setInputMessage('');
+    setSuggestions([]);
     setLoading(true);
 
     try {
@@ -138,6 +162,9 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
+    } else if (e.key === 'Tab' && suggestions.length > 0) {
+      e.preventDefault();
+      handleSuggestionClick(suggestions[0]);
     }
     // Allow Shift+Enter for new lines in multiline input
   };
@@ -307,7 +334,7 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
             <div className="chat-input-container">
               <InputTextarea
                   value={inputMessage}
-                  onChange={(e) => setInputMessage(e.target.value)}
+                  onChange={handleInputChange}
                   onKeyDown={handleKeyPress}
                   placeholder={`Type your message to ${selectedServer.name}... (Enter to send, Shift+Enter for new line)`}
                   className="chat-input-field"
@@ -322,6 +349,15 @@ export const ChatInterface = ({ selectedServer, toolsAcknowledged = false }) => 
                   className="chat-send-button"
               />
             </div>
+            {suggestions.length > 0 && (
+              <ul className="chat-suggestions">
+                {suggestions.map((s) => (
+                  <li key={s} onClick={() => handleSuggestionClick(s)}>
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </Card>
       </div>

--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -172,6 +172,7 @@
   border-top: 1px solid #e0e0e0;
   background: white;
   flex-shrink: 0;
+  position: relative;
 }
 
 .chat-input-container {
@@ -216,6 +217,31 @@
 .chat-send-button:disabled {
   background: #ccc;
   cursor: not-allowed;
+}
+
+.chat-suggestions {
+  position: absolute;
+  bottom: 60px;
+  left: 1rem;
+  right: 1rem;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  max-height: 150px;
+  overflow-y: auto;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  z-index: 10;
+}
+
+.chat-suggestions li {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.chat-suggestions li:hover {
+  background: #f0f0f0;
 }
 
 /* Empty chat state */


### PR DESCRIPTION
## Summary
- suggest server tool names while typing
- autocomplete the first suggestion with Tab or click
- style suggestion dropdown under the chat input

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d8f31ba0832ebb130cd2c537da25