### PR TITLE
refactor: improve MCP tool handling

### DIFF
--- a/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
+++ b/backend/src/main/java/org/shark/mentor/mcp/service/McpToolOrchestrator.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.shark.mentor.mcp.model.McpServer;
 import org.springframework.stereotype.Service;
 
-import java.io.*;
 import java.util.*;
 
 /**
@@ -71,16 +70,7 @@ public class McpToolOrchestrator {
     public String scheduleToolCall(McpServer server, Map<String, Object> toolCall) throws Exception {
         String protocol = extractProtocol(server.getUrl());
 
-        if ("stdio".equalsIgnoreCase(protocol)) {
-            OutputStream stdin = mcpServerService.getStdioInput(server.getId());
-            InputStream stdout = mcpServerService.getStdioOutput(server.getId());
-            if (stdin == null || stdout == null) {
-                throw new IllegalStateException("STDIO streams not available for server: " + server.getId());
-            }
-            return mcpToolService.callToolViaStdio(stdin, stdout, toolCall);
-        } else {
-            return mcpToolService.callToolViaHttp(server, toolCall);
-        }
+        return mcpToolService.callTool(server, toolCall);
     }
 
     public Map<String, Object> prepareToolCall(Map<String, Object> toolSchema, Map<String, Object> arguments) {

--- a/backend/src/test/java/org/shark/mentor/mcp/service/McpToolParameterExtractionTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/McpToolParameterExtractionTest.java
@@ -81,7 +81,7 @@ class McpToolParameterExtractionTest {
         );
         
         // When LLM tries to extract the query parameter
-        when(llmService.generate(anyString(), anyString())).thenReturn("SELECT * FROM users");
+        when(llmService.generate(anyString(), anyString())).thenReturn("{\"query\":\"SELECT * FROM users\"}");
         
         // Create a custom McpToolService that we can control
         McpToolService testService = new McpToolService(mcpServerService, llmService) {
@@ -172,12 +172,12 @@ class McpToolParameterExtractionTest {
         };
         
         // Test with LLM returning valid value
-        when(llmService.generate(anyString(), anyString())).thenReturn("SELECT * FROM users");
+        when(llmService.generate(anyString(), anyString())).thenReturn("{\"query\":\"SELECT * FROM users\"}");
         Map<String, Object> args = testService.extractToolArguments("show all users", "query_data");
         assertEquals("SELECT * FROM users", args.get("query"));
-        
+
         // Test with LLM returning NULL
-        when(llmService.generate(anyString(), anyString())).thenReturn("NULL");
+        when(llmService.generate(anyString(), anyString())).thenReturn("{\"query\":null}");
         args = testService.extractToolArguments("show", "query_data");
         assertEquals("show", args.get("query")); // Should fallback to user message for required params
         

--- a/backend/src/test/java/org/shark/mentor/mcp/service/McpToolParameterFixIntegrationTest.java
+++ b/backend/src/test/java/org/shark/mentor/mcp/service/McpToolParameterFixIntegrationTest.java
@@ -93,7 +93,7 @@ class McpToolParameterFixIntegrationTest {
         assertTrue(arguments.isEmpty(), "Arguments should be empty for list_tables");
 
         // Test 4: Compare with query_data tool that does require parameters
-        when(llmService.generate(anyString(), anyString())).thenReturn("SELECT * FROM tables");
+        when(llmService.generate(anyString(), anyString())).thenReturn("{\"query\":\"SELECT * FROM tables\"}");
         Map<String, Object> queryDataArgs = testService.extractToolArguments("show me all tables", "query_data");
         assertFalse(queryDataArgs.isEmpty(), "query_data should extract parameters");
         assertTrue(queryDataArgs.containsKey("query"), "query_data should have query parameter");


### PR DESCRIPTION
## Summary
- unify MCP tool calls to support HTTP/STDIO with streaming responses
- validate and extract tool arguments in a single LLM pass
- show available tools on initial chat connection

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f96a2fc832e8b93478abb9959ed