### PR TITLE
feat: enable message editing and copying

### DIFF
--- a/ui/src/styles/chat-interface.css
+++ b/ui/src/styles/chat-interface.css
@@ -109,14 +109,29 @@
 
 .chat-message-header {
   display: flex;
-  gap: 0.5rem;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 0.25rem;
   font-size: 0.75rem;
   color: #666;
 }
 
+.chat-message-meta {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .chat-message.user .chat-message-header {
   flex-direction: row-reverse;
+}
+
+.chat-message.user .chat-message-meta {
+  flex-direction: row-reverse;
+}
+
+.chat-message-actions {
+  display: flex;
+  gap: 0.25rem;
 }
 
 .chat-message-text {


### PR DESCRIPTION
## Summary
- allow editing of past user messages with conversation replay
- add copy icon for all chat messages
- style message header to support action buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689a76ce4c7c832e84755a6546f1d202